### PR TITLE
REST server as endpoint of RemotePCIeTransport

### DIFF
--- a/scripts/casperfpga_rest_server.py
+++ b/scripts/casperfpga_rest_server.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python
+import logging
+
+from flask import Flask, request, make_response, send_file
+from werkzeug.utils import secure_filename
+from flask_restful import Resource, Api, reqparse
+
+from io import StringIO
+import os
+import base64
+import casperfpga
+from casperfpga.transport_localpcie import LocalPcieTransport
+from casperfpga.utils import parse_fpg
+from datetime import datetime
+
+__author__ = 'radonnachie'
+__date__ = 'Feb 2022'
+
+LOGGER = logging.getLogger(__name__)
+
+UPLOAD_FOLDER = '/tmp'
+ALLOWED_EXTENSIONS = {'fpg'}
+def allowed_file(filename):
+    return '.' in filename and \
+           filename.rsplit('.', 1)[1].lower() in ALLOWED_EXTENSIONS
+
+app = Flask(__name__)
+api = Api(app)
+app.config['UPLOAD_FOLDER'] = UPLOAD_FOLDER
+
+TRANSPORT_TARGET_DICT = {}
+
+def LOG_INFO(str):
+    LOGGER.info(str)
+    print(str)
+
+class TransportTarget(object):
+    def __init__(self, target, cfpga = None):
+        self.target = target
+        self.cfpga = cfpga
+        self.fpgfile_path = None
+
+        if self.cfpga is None:
+            LOG_INFO('Connecting to "{}"'.format(target))
+            self.cfpga = casperfpga.CasperFpga(
+                        host=target,
+                        transport=casperfpga.LocalPcieTransport,
+                )
+    
+    def __del__(self):
+        if self.cfpga is not None:
+            self.cfpga.disconnect()
+    
+    def _setFpgfile_path(self, fpgfile_path):
+        LOG_INFO('"{}" is programmed with "{}"'.format(self.target, fpgfile_path))
+        self.fpgfile_path = fpgfile_path
+        self.cfpga.get_system_information(self.fpgfile_path)
+    
+    def upload_to_ram_and_program(self, fpgfile_path):
+        if fpgfile_path != self.fpgfile_path:
+            if (self.fpgfile_path is not None and
+                os.path.exists(self.fpgfile_path) and
+                self.fpgfile_path.startswith(app.config['UPLOAD_FOLDER'])
+            ):
+
+                LOG_INFO('Removing previously uploaded fpg file for "{}": "{}"'.format(self.target, fpgfile_path))
+                os.remove(self.fpgfile_path)
+            
+            LOG_INFO('Programming "{}" with "{}"'.format(self.target, fpgfile_path))
+            self.cfpga.transport.upload_to_ram_and_program(fpgfile_path)
+            self._setFpgfile_path(fpgfile_path)
+        return True
+    
+    def is_connected(self, timeout=None, retries=None):
+        return self.cfpga.transport.is_connected(timeout, retries)
+
+def getTransportTarget(target):
+    if target not in TRANSPORT_TARGET_DICT:
+        TRANSPORT_TARGET_DICT[target] = TransportTarget(target)
+    return TRANSPORT_TARGET_DICT[target]
+
+class RestTransport_Device(Resource):
+    def get(self, target, device_name):
+        transportTarget = getTransportTarget(target)
+
+        size = request.args.get('size', type = int)
+        offset = request.args.get('offset', default = 1, type = int)
+
+        try:
+            bytes_read = transportTarget.cfpga.transport.read(device_name, size, offset)
+            response = make_response(bytes_read, 200, {'Content-Type': 'application/octet-stream'})
+        except:
+            response = make_response({
+                'response': 'Failed to read. Confirm device_name \'{}\'.'.format(device_name),
+            }, 404)
+        return response#, code
+    
+    def put(self, target, device_name):
+        transportTarget = getTransportTarget(target)
+        offset = request.args.get('offset', default = 0, type = int)
+        data = request.data
+
+        try:
+            transportTarget.cfpga.transport.blindwrite(device_name, data, offset)
+            bytes_read = transportTarget.cfpga.transport.read(device_name, len(data), offset)
+            response = make_response(bytes_read, 200, {'Content-Type': 'application/octet-stream'})
+        except:
+            response = make_response({
+                'response': 'Unknown device_name \'{}\''.format(device_name),
+                'device_names': list(transportTarget.cfpga.listdev()),
+            }, 404)
+        return response
+
+class RestTransport_DeviceList(Resource):
+    def get(self, target):
+        transportTarget = getTransportTarget(target)
+
+        device_name = request.args.get('device_name', default = None, type = str)
+
+        try:
+            response_val = list(transportTarget.cfpga.listdev())
+            if device_name is not None:
+                response_val = device_name in response_val
+            response = {
+                'response': response_val,
+            }
+            code = 200
+        except:
+            response = {
+                'response': 'Failed to listdev',
+            }
+            code = 500
+        return response, code
+
+class RestTransport_FpgFile(Resource):
+    def get(self, target):
+        transportTarget = getTransportTarget(target)
+
+        try:
+            send_file(transportTarget.fpgfile_path)
+        except:
+            response = {
+                'response':  'Failed to send fpgafile: {}'.format(transportTarget.fpgfile_path)
+            }
+            code = 500
+        return response, code
+
+
+    def put(self, target):
+        filepath = None
+
+        transportTarget = getTransportTarget(target)
+        try:
+            if 'fpga' in request.files:
+                file = request.files['fpga']
+                # If the user does not select a file, the browser submits an
+                # empty file without a filename.
+                assert file.filename != ''
+                if file and allowed_file(file.filename):
+                    filename = secure_filename(file.filename)
+                    filepath = os.path.join(
+                        app.config['UPLOAD_FOLDER'],
+                        '{}{}'.format(
+                            datetime.now().strftime("%Y-%m-%d_%Hh%Mm%S_"),
+                            filename
+                        )
+                    )
+                    file.save(filepath)
+            else:
+                filepath = request.args.get('fpgfile_path')
+
+            transportTarget.upload_to_ram_and_program(filepath)
+            response = {
+                'response':  transportTarget.fpgfile_path
+            }
+            code = 200
+        except:
+            if filepath is not None:
+                response = {
+                    'response':  'Error programming with "{}".'.format(filepath)
+                }
+                code = 500
+            else:
+                response = {
+                    'response':  'Either upload a file or provide a server-local fileos.path.'
+                }
+                code = 500
+
+        return response, code
+
+class RestTransport_IsConnected(Resource):
+    def get(self, target):
+        transportTarget = getTransportTarget(target)
+        
+        timeout = request.args.get('timeout', default = None, type = int)
+        retries = request.args.get('retries', default = None, type = int)
+
+        try:
+            response = {
+                'response':  transportTarget.is_connected(timeout, retries)
+            }
+            code = 200
+        except:
+            response = {
+                'response':  'TransportTarget not created'
+            }
+            code = 500
+        return response, code
+
+class RestTransport_IsProgrammed(Resource):
+    def get(self, target):
+        transportTarget = getTransportTarget(target)
+        response = {
+            'response':  transportTarget.fpgfile_path is not None
+        }
+        code = 200
+        return response, code
+
+class RestTransport_Version(Resource):
+    def get(self):
+        return {
+            'response': '1.0.0'
+        }, 200
+
+api.add_resource(RestTransport_Device, '/<string:target>/device/<string:device_name>')
+api.add_resource(RestTransport_DeviceList, '/<string:target>/device')
+api.add_resource(RestTransport_FpgFile, '/<string:target>/fpgfile')
+api.add_resource(RestTransport_IsConnected, '/<string:target>/connected')
+api.add_resource(RestTransport_IsProgrammed, '/<string:target>/programmed')
+api.add_resource(RestTransport_Version, '/version')
+
+if __name__ == '__main__':
+    app.run(debug=False)  # run our Flask app
+    # TODO disconnect instances when closing
+    # for (target, cfpga) in TARGET_CFPGA_DICT.items():
+    #     print('Disconnecting from "{}"'.format(target))
+    #     cfpga.disconnect()

--- a/scripts/casperfpga_rest_server.py
+++ b/scripts/casperfpga_rest_server.py
@@ -84,11 +84,16 @@ class RestTransport_Device(Resource):
         transportTarget = getTransportTarget(target)
 
         size = request.args.get('size', type = int)
-        offset = request.args.get('offset', default = 1, type = int)
+        offset = request.args.get('offset', default = 0, type = int)
 
         try:
             bytes_read = transportTarget.cfpga.transport.read(device_name, size, offset)
-            response = make_response(bytes_read, 200, {'Content-Type': 'application/octet-stream'})
+            response = make_response(bytes_read, 200,
+                {
+                    'Content-Type': 'application/octet-stream',
+                    'Content-Length': str(size)
+                }
+            )
         except:
             response = make_response({
                 'response': 'Failed to read. Confirm device_name \'{}\'.'.format(device_name),
@@ -103,7 +108,13 @@ class RestTransport_Device(Resource):
         try:
             transportTarget.cfpga.transport.blindwrite(device_name, data, offset)
             bytes_read = transportTarget.cfpga.transport.read(device_name, len(data), offset)
-            response = make_response(bytes_read, 200, {'Content-Type': 'application/octet-stream'})
+
+            response = make_response(bytes_read, 200,
+                {
+                    'Content-Type': 'application/octet-stream',
+                    'Content-Length': str(len(data))
+                }
+            )
         except:
             response = make_response({
                 'response': 'Unknown device_name \'{}\''.format(device_name),
@@ -230,7 +241,7 @@ api.add_resource(RestTransport_IsProgrammed, '/<string:target>/programmed')
 api.add_resource(RestTransport_Version, '/version')
 
 if __name__ == '__main__':
-    app.run(debug=False)  # run our Flask app
+    app.run(host='0.0.0.0', debug=False)  # run our Flask app
     # TODO disconnect instances when closing
     # for (target, cfpga) in TARGET_CFPGA_DICT.items():
     #     print('Disconnecting from "{}"'.format(target))

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -12,6 +12,7 @@ from .transport_skarab import SkarabTransport
 from .transport_itpm import ItpmTransport
 from .transport_redis import RedisTapcpTransport
 from .transport_localpcie import LocalPcieTransport
+from .transport_remotepcie import RemotePcieTransport
 from .memory import Memory
 from .network import IpAddress, Mac
 from .qdr import Qdr

--- a/src/transport_remotepcie.py
+++ b/src/transport_remotepcie.py
@@ -1,0 +1,221 @@
+import logging
+import time
+import os
+import requests
+import json
+
+from .transport import Transport
+
+__author__ = 'radonnachie'
+__date__ = 'Feb 2022'
+
+class RemotePcieTransport(Transport):
+    """
+    The transport interface for a remote PCIe FPGA card (behind a REST server).
+    """
+
+    def __init__(self, **kwargs):
+        """
+        :param uri: URI for the remote machine hosting the target PCIe FPGA card.
+        """
+        Transport.__init__(self, **kwargs)
+
+        try:
+            # Entry point is always via casperfpga.CasperFpga
+            self.server_uri = kwargs['uri']
+            # self.logger = self.parent.logger
+            self.logger = logging.getLogger(__name__)
+            self.logger.setLevel(logging.INFO)
+        except KeyError:
+            errmsg = 'uri argument not supplied when creating RemotePcieTransport'
+            # Pointless trying to log to a logger
+            raise RuntimeError(errmsg)
+
+        try:
+            response = requests.get(url=self.server_uri+'/version')
+            if response.status_code == 200:
+                assert response.json()['response'] == '1.0.0'
+        except:
+            errmsg = 'Server at uri not functional or not version 1.0.0:\n\t{} responded with {}'.format(self.server_uri, response.json())
+            raise RuntimeError(errmsg)
+
+        self.instance_id = kwargs.get('instance_id', 0)
+
+        new_connection_msg = '*** NEW REST CLIENT MADE TO {} ***'.format(self.server_uri)
+        self.logger.info(new_connection_msg)
+        print(new_connection_msg)
+
+    def _content_type(self, data): # returns adjusted data, {"Content-Type": }
+        if isinstance(data, dict):
+            try:
+                return json.dumps(data), {"Content-Type": "application/json"}
+            except:
+                pass
+        return bytes(data), {"Content-Type": 'application/octet-stream'}
+
+    def _put(self, endpoint, data = None, params = None, files = None):
+        uri = self.server_uri + '/' + self.host + endpoint
+        self.logger.info(uri)
+        if data is None and files is None:
+            return requests.put(url=uri, params=params)
+        elif files is not None:
+            return requests.put(url=uri, params=params, files=files)
+        else: # data is only non-None
+            reqdata, header = self._content_type(data)
+            return requests.put(url=uri, params=params, data=reqdata, headers=header)
+
+    def _get(self, endpoint, data = None, params = None):
+        uri = self.server_uri + '/' + self.host + endpoint
+        self.logger.info(uri)
+        if data is None:
+            return requests.get(url=uri, params=params)
+        else: # data is only non-None
+            reqdata, header = self._content_type(data)
+            return requests.get(url=uri, params=params, data=reqdata, headers=header)
+
+    def is_connected(self,
+                     timeout=None,
+                     retries=None):
+        """
+        'ping' the server to see if the board is connected and running.
+        Tries to read a register
+
+        :return: Boolean - True/False - Success/Fail
+        """
+        if timeout is None: timeout=self.timeout
+        if retries is None: retries=self.retries
+
+        response = self._get(
+            '/connected',
+            params = {
+                'timeout': timeout,
+                'retries': retries,
+            }
+        )
+        if response.status_code == 200:
+            self.logger.debug(response.json())
+            return response.json()['response']
+        else:
+            self.logger.warning(response.json())
+            raise RuntimeError(response.json())
+
+    def is_programmed(self):
+        """
+        Ask the server if it knows the fpg file for the board.
+
+        :return: Boolean - True/False - Success/Fail
+        """
+
+        response = self._get(
+            '/programmed',
+        )
+        if response.status_code == 200:
+            self.logger.debug(response.json())
+            return response.json()['response']
+        else:
+            self.logger.warning(response.json())
+            raise RuntimeError(response.json())
+
+    def is_running(self):
+        """
+        Is the FPGA programmed and running a toolflow image?
+
+        *** Not yet implemented ***
+
+        :return: True or False
+        """
+        return True
+
+    def read(self, device_name, size, offset=0):
+        """
+        Read size-bytes of binary data.
+
+        :param device_name: name of memory device from which to read
+        :param size: how many bytes to read
+        :param offset: start at this offset, offset in bytes
+        :return: binary data string
+        """
+        response = self._get(
+            '/device/'+device_name,
+            params = {
+                'size': size,
+                'offset': offset,
+            }
+        )
+        if response.status_code == 200:
+            return response.content
+        else:
+            self.logger.warning(response.json())
+            raise RuntimeError(response.json())
+
+
+    def blindwrite(self, device_name, data, offset=0):
+        """
+        Unchecked data write.
+
+        :param device_name: the memory device to which to write
+        :param data: the byte string to write
+        :param offset: the offset, in bytes, at which to write
+        """
+
+        size = len(data)
+        assert (type(data) == bytes), 'Must supply binary data'
+        assert (size % 4 == 0), 'Must write 32-bit-bounded words'
+        assert (offset % 4 == 0), 'Must write 32-bit-bounded words'
+
+        response = self._put(
+            '/device/'+device_name,
+            params = {
+                'offset': offset,
+            },
+            data = data,
+        )
+        if response.status_code != 200:
+            self.logger.warning(response.json())
+            raise RuntimeError(response.json())
+
+    def upload_to_ram_and_program(self, filename, wait_complete=None):
+        """
+        Uploads an FPGA PR image over PCIe. This image _must_ have been
+        generated using an appropriate partial reconfiguration flow.
+        """
+        assert filename.endswith('.fpg')
+
+        response = self._put(
+            '/fpgfile',
+            files = {'fpga': open(filename, 'rb')}
+        )
+        if response.status_code == 200:
+            self.logger.debug(response.json())
+            return True
+        else:
+            self.logger.warning(response.json())
+            return False
+
+    def listdev(self):
+        """
+        Interface for remote transport's listdev function.
+
+        :return: list of device_names
+        """
+        response = self._get(
+            '/device',
+        )
+        if response.status_code == 200:
+            return response.json()['response']
+        else:
+            self.logger.warning(response.json())
+            raise RuntimeError(response.json())
+
+
+if __name__ == "__main__":
+    # some basic tests
+    DEFAULT_FPGFILE = "/home/cosmic/src/vla-dev/adm_pcie_9h7_dts_dual_2x100g_dsp_8b/outputs/cosmic_feng_8b.fpg"
+
+    remotepcie = RemotePcieTransport(uri='http://localhost:5000', host='pcie0')
+    if remotepcie.is_connected(0, 0) and not remotepcie.is_programmed():
+        print("Programmed Successfully:", remotepcie.upload_to_ram_and_program(DEFAULT_FPGFILE))
+    print(remotepcie.listdev())
+    print(remotepcie.read('version_type', 4))
+    remotepcie.blindwrite('version_type', bytes([2,0,0,1]))
+    print(remotepcie.read('version_type', 4))


### PR DESCRIPTION
`pip install requests flask flask_restful` I think that's all.

run `casperfpga_rest_server.py` on machine with LocalPCIeTransport FPGAs.
`curl -GET http://server-ip:5000/version`

Employ `RemotePCIeTransport` (see the `if __name__ == '__main__':` at the end of `transport_remotepcie.py`).
