### PR TITLE
Move PCIe template-match programming conditional to Transport level

### DIFF
--- a/src/transport_localpcie.py
+++ b/src/transport_localpcie.py
@@ -181,9 +181,9 @@ class LocalPcieTransport(Transport):
         generated using an appropriate partial reconfiguration flow.
         """
         assert filename.endswith('.fpg')
+        template = self._parse_template_meta(filename)
         if self.fpg_template is not None:
             # assert that the file's template matches
-            template = self._parse_template_meta(filename)
             if self.fpg_template != template:
                 raise RuntimeError(("Programmed image is "
                     "templated by `{}`. Supplied image has mismatching template"
@@ -201,6 +201,9 @@ class LocalPcieTransport(Transport):
         #    fh.write(bitstream)
 
         #subprocess.run(['dma_to_device', '-d', self._axid_dev, '-s', str(size), '-c', '1', '-f', binfile_temp], check=True)
+            
+        if self.fpg_template is None and template is not None:
+            self.fpg_template = template
 
         return True
 


### PR DESCRIPTION
- `LocalPcieTransport` constructor takes `fpgfile` kwarg, from which the `self.fpg_template` criterion is set
- `upload_to_ram_and_program` asserts that the `pr_template` meta key of the provided fpgfile matches `self.fpg_template`, if that criterion isn't None.
- `upload_to_ram_and_program` sets `self.fpg_template` to the `pr_template` meta key of the provided fpgfile if that criterion is None.
 