### PR TITLE
Move target to xdma ID mapping to Transport level

### DIFF
--- a/scripts/casperfpga_rest_server.py
+++ b/scripts/casperfpga_rest_server.py
@@ -39,8 +39,8 @@ XDMA_PCIE_DICT = None
 PCIE_XDMA_DICT = None
 
 class TransportTarget(object):
-    def __init__(self, target_device, cfpga = None, **kwargs):
-        self.target = 'pcie%s'%XDMA_PCIE_DICT[target_device]
+    def __init__(self, xdma_id, cfpga = None, **kwargs):
+        self.target = 'pcie%s'%XDMA_PCIE_DICT[xdma_id]
         self.cfpga = cfpga
         self.fpgfile_path = None
         self.fpg_template = None
@@ -84,7 +84,8 @@ class TransportTarget(object):
         return self.cfpga.transport.is_connected(timeout, retries)
 
 def getTransportTarget(target, **kwargs):
-    xdma_id = LocalPcieTransport.getXdmaIdFromTarget(target) if target not in XDMA_PCIE_DICT.keys() else target
+    # translate target to xdma_id for uniformity of TransportTarget.host
+    xdma_id = LocalPcieTransport.getXdmaIdFromTarget(target, PCIE_XDMA_DICT)
     if xdma_id not in TRANSPORT_TARGET_DICT:
         TRANSPORT_TARGET_DICT[xdma_id] = TransportTarget(xdma_id, **kwargs)
     return TRANSPORT_TARGET_DICT[xdma_id]

--- a/scripts/casperfpga_rest_server.py
+++ b/scripts/casperfpga_rest_server.py
@@ -293,7 +293,7 @@ if __name__ == '__main__':
             localtransport._setFpgfile_path(args.fpgfile)
 
 
-    app.run(host='0.0.0.0', port=5002, debug=False)  # run our Flask app
+    app.run(host='0.0.0.0', port=5000, debug=False)  # run our Flask app
     # TODO disconnect instances when closing
     # for (target, cfpga) in TARGET_CFPGA_DICT.items():
     #     print('Disconnecting from "{}"'.format(target))

--- a/src/transport_localpcie.py
+++ b/src/transport_localpcie.py
@@ -28,8 +28,8 @@ class LocalPcieTransport(Transport):
 
     def __init__(self, **kwargs):
         """
+        :param host: The host-device identifier string (see `getXdmaIdFromTarget`)
         :param parent_fpga: Instance of parent_fpga
-        :param instance_id: `xdma{id}` of target device
         :param fpgfile: filepath to fpg image, setting the fpg template
             restriction
         """
@@ -128,6 +128,9 @@ class LocalPcieTransport(Transport):
 
     @staticmethod
     def getXdmaIdFromTarget(target, pcie_xdma_map = None):
+        '''
+        :param target: Identifier of target PCIe device [pcieAB, xdmaXX, or direct xdma ID].
+        '''
         if pcie_xdma_map is None:
             logging.info("Generating local pcie_xdma_map")
             pcie_xdma_dict = LocalPcieTransport.get_pcie_xdma_map()

--- a/src/transport_localpcie.py
+++ b/src/transport_localpcie.py
@@ -137,6 +137,7 @@ class LocalPcieTransport(Transport):
         else:
             logging.info("Using supplied pcie_xdma_map")
             pcie_xdma_dict = pcie_xdma_map
+        
         if target.startswith('pcie'):
             logging.info("Target supplied with pcie id, mapping to xdma id")
             pci_id = target[4:]
@@ -151,6 +152,12 @@ class LocalPcieTransport(Transport):
         if target.startswith('xdma'):
             logging.info("Target supplied with xdma id, mapping to pcie id")
             return target[4:]
+
+        try:
+            if int(target) in pcie_xdma_dict.values():
+                return int(target)
+        except: # target was not an integer
+            pass
 
         raise RuntimeError((
             'Specified target "{}" not recognised:\nmust begin with either "pcie"'


### PR DESCRIPTION
- `LocalPcieTransport` takes a `target` kwarg, maps it to an xdma id and sets `self.instance_id`.
- Informational logging done in the xdma2pcie/pcie2xdma details the mapping direction underway.
- `get_pcie_xdma_map` and `getXdmaIdFromTarget` are static methods where one may supply `getXdmaIdFromTarget` with a custom pcie_xdma_map.
- `TransportTarget` now only takes in a `target_device` since mapping to xdma is done in the local transport layer.